### PR TITLE
add dependency on gencfg so that it is built before this target

### DIFF
--- a/yocs_velocity_smoother/CMakeLists.txt
+++ b/yocs_velocity_smoother/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(velocity_smoother_nodelet src/velocity_smoother_nodelet.cpp)
 
 
 target_link_libraries(velocity_smoother_nodelet ${catkin_LIBRARIES})
+add_dependencies(velocity_smoother_nodelet ${PROJECT_NAME}_gencfg)
 
 install(TARGETS velocity_smoother_nodelet
         DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}


### PR DESCRIPTION
CMakeFiles/velocity_smoother_nodelet.dir/src/velocity_smoother_nodelet.cpp.o -c /tmp/buildd/ros-hydro-yocs-velocity-smoother-0.4.0-0precise-20130922-0627/src/velocity_smoother_nodelet.cpp
/tmp/buildd/ros-hydro-yocs-velocity-smoother-0.4.0-0precise-20130922-0627/src/velocity_smoother_nodelet.cpp:18:49: fatal error: yocs_velocity_smoother/paramsConfig.h: No such file or directory
compilation terminated.
