### PR TITLE
Add support for YAML-CPP 0.5+.

### DIFF
--- a/yocs_cmd_vel_mux/CMakeLists.txt
+++ b/yocs_cmd_vel_mux/CMakeLists.txt
@@ -4,7 +4,11 @@ find_package(catkin REQUIRED COMPONENTS roscpp pluginlib nodelet dynamic_reconfi
 
 # pkg-config support
 find_package(PkgConfig)
-pkg_search_module(REQUIRED yaml-cpp)
+pkg_search_module(yaml-cpp REQUIRED yaml-cpp)
+
+if(NOT ${yaml-cpp_VERSION} VERSION_LESS "0.5")
+add_definitions(-DHAVE_NEW_YAMLCPP)
+endif()
 
 # Dynamic reconfigure support
 generate_dynamic_reconfigure_options(cfg/reload.cfg)
@@ -23,8 +27,7 @@ add_library(${PROJECT_NAME}_nodelet src/cmd_vel_mux_nodelet.cpp src/cmd_vel_subs
 add_dependencies(${PROJECT_NAME}_nodelet geometry_msgs_gencpp)
 add_dependencies(${PROJECT_NAME}_nodelet ${PROJECT_NAME}_gencfg)
 
-target_link_libraries(${PROJECT_NAME}_nodelet ${catkin_LIBRARIES})
-target_link_libraries(${PROJECT_NAME}_nodelet yaml-cpp)
+target_link_libraries(${PROJECT_NAME}_nodelet ${catkin_LIBRARIES} ${yaml-cpp_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME}_nodelet
         DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/yocs_cmd_vel_mux/include/yocs_cmd_vel_mux/cmd_vel_subscribers.hpp
+++ b/yocs_cmd_vel_mux/include/yocs_cmd_vel_mux/cmd_vel_subscribers.hpp
@@ -21,6 +21,16 @@
 #include <geometry_msgs/Twist.h>
 #include <yaml-cpp/yaml.h>
 
+#ifdef HAVE_NEW_YAMLCPP
+// The >> operator disappeared in yaml-cpp 0.5, so this function is
+// added to provide support for code written under the yaml-cpp 0.3 API.
+template<typename T>
+void operator >> (const YAML::Node& node, T& i)
+{
+  i = node.as<T>();
+}
+#endif
+
 /*****************************************************************************
 ** Preprocessing
 *****************************************************************************/

--- a/yocs_cmd_vel_mux/src/cmd_vel_mux_nodelet.cpp
+++ b/yocs_cmd_vel_mux/src/cmd_vel_mux_nodelet.cpp
@@ -117,18 +117,28 @@ void CmdVelMuxNodelet::reloadConfiguration(yocs_cmd_vel_mux::reloadConfig &confi
     return;
   }
   // probably need to bring the try catches back here
-  YAML::Parser parser(ifs);
   YAML::Node doc;
+#ifdef HAVE_NEW_YAMLCPP
+  doc = YAML::Load(ifs);
+#else
+  YAML::Parser parser(ifs);
   parser.GetNextDocument(doc);
+#endif
 
   /*********************
   ** Output Publisher
   **********************/
   std::string output_name("output");
+#ifdef HAVE_NEW_YAMLCPP
+  if ( doc["publisher"] ) {
+    doc["publisher"] >> output_name;
+  }
+#else
   const YAML::Node *node = doc.FindValue("publisher");
   if ( node != NULL ) {
     *node >> output_name;
   }
+#endif
   mux_cmd_vel_pub = nh.advertise <geometry_msgs::Twist> (output_name, 10);
 
   /*********************

--- a/yocs_cmd_vel_mux/src/cmd_vel_subscribers.cpp
+++ b/yocs_cmd_vel_mux/src/cmd_vel_subscribers.cpp
@@ -31,7 +31,11 @@ void CmdVelSubscribers::CmdVelSubs::operator << (const YAML::Node& node)
   node["topic"]      >> topic;
   node["timeout"]    >> timeout;
   node["priority"]   >> priority;
+#ifdef HAVE_NEW_YAMLCPP
+  if (node["short_desc"]) {
+#else
   if (node.FindValue("short_desc") != NULL) {
+#endif
     node["short_desc"] >> short_desc;
   }
 }

--- a/yocs_waypoints_navi/CMakeLists.txt
+++ b/yocs_waypoints_navi/CMakeLists.txt
@@ -6,7 +6,11 @@ find_package(catkin REQUIRED COMPONENTS visualization_msgs move_base_msgs action
 
 # pkg-config support
 find_package(PkgConfig)
-pkg_search_module(REQUIRED yaml-cpp)
+pkg_search_module(yaml-cpp REQUIRED yaml-cpp)
+
+if(NOT ${yaml-cpp_VERSION} VERSION_LESS "0.5")
+add_definitions(-DHAVE_NEW_YAMLCPP)
+endif()
 
 catkin_package(
     INCLUDE_DIRS
@@ -19,7 +23,7 @@ include_directories(${catkin_INCLUDE_DIRS} ${yaml-cpp_INCLUDE_DIRS})
 
 # building c++ executables and libraries
 add_executable(${PROJECT_NAME}_node src/waypoints_navi.cpp)
-target_link_libraries(${PROJECT_NAME}_node ${catkin_LIBRARIES} ${Boost_LIBRARIES} yaml-cpp)
+target_link_libraries(${PROJECT_NAME}_node ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${yaml-cpp_LIBRARIES})
 
 
 #############


### PR DESCRIPTION
The new yaml-cpp API removes the "node >> outputvar;" operator, and
it has a new way of loading documents. There's no version hint in the
library's headers, so I'm getting the version number from pkg-config.

This part of the patch is a port of the ones created by @ktossell for
map_server and other packages.

The new yaml-cpp also does not have FindValue.
