### PR TITLE
Add depend on yaml-cpp for yocs_ar_marker_tracking

### DIFF
--- a/yocs_ar_marker_tracking/package.xml
+++ b/yocs_ar_marker_tracking/package.xml
@@ -16,11 +16,13 @@
   <build_depend>roscpp</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>yaml-cpp</build_depend>
   <build_depend>yocs_math_toolkit</build_depend>
   <run_depend>ar_track_alvar_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>yaml-cpp</run_depend>
   <run_depend>yocs_math_toolkit</run_depend>
 
 </package>


### PR DESCRIPTION
`yaml-cpp` is clearly referenced in the `CMakeLists.txt`, so it should be a dependency in the `package.xml`.

Example of build failure due to this bug: http://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-yocs-ar-marker-tracking_binaryrpm_heisenbug_x86_64/3/console

Thanks,

--scott
