### PR TITLE
Add dependency regarding yocs message

### DIFF
--- a/yocs_joyop/CMakeLists.txt
+++ b/yocs_joyop/CMakeLists.txt
@@ -18,6 +18,7 @@ include_directories(${catkin_INCLUDE_DIRS})
 add_executable(joyop src/joyop.cpp)
 
 target_link_libraries(joyop ${catkin_LIBRARIES})
+add_dependencies(joyop yocs_msgs_gencpp)
 
 install(TARGETS joyop 
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})


### PR DESCRIPTION
The following error is occurred in compile process.

```
/home/yujin/ros/waiterbot/src/yujin_ocs/yocs_joyop/src/joyop.cpp:11:35: fatal error: yocs_msgs/MagicButton.h: No such file or directory
 #include <yocs_msgs/MagicButton.h>
                                   ^
compilation terminated.

```
