### PR TITLE
Minor, but critical bugfixes to angle handling in the diff drive pose controller

### DIFF
--- a/yocs_diff_drive_pose_controller/src/diff_drive_pose_controller.cpp
+++ b/yocs_diff_drive_pose_controller/src/diff_drive_pose_controller.cpp
@@ -42,8 +42,8 @@ DiffDrivePoseController::DiffDrivePoseController(std::string name, double v_max,
 void DiffDrivePoseController::setInput(double distance_to_goal, double delta, double theta)
 {
   r_ = distance_to_goal;
-  delta_ = delta;
-  theta_ = theta;
+  delta_ = mtk::wrapAngle(delta);
+  theta_ = mtk::wrapAngle(theta);
 }
 
 void DiffDrivePoseController::setCurrentLimits(double v_min, double w_min, double v_max, double w_max)
@@ -101,9 +101,9 @@ void DiffDrivePoseController::calculateControls()
 
 void DiffDrivePoseController::controlPose()
 {
-  double atan2_k1_tehta = std::atan2(-theta_, k_1_);
+  double atan2_k1_theta = std::atan2(-k_1_*theta_, 1.0);
   cur_ = (-1 / r_)
-      * (k_2_ * (delta_ - atan2_k1_tehta) + (1 + (k_1_ / (1 + std::pow((k_1_ * theta_), 2)))) * sin(delta_));
+      * (k_2_ * (delta_ - atan2_k1_theta) + (1 + (k_1_ / (1 + std::pow((k_1_ * theta_), 2)))) * sin(delta_));
 
   v_ = v_max_ / (1 + beta_ * std::pow(std::abs(cur_), lambda_));
   v_ = enforceMinVelocity(v_, v_min_movement_);


### PR DESCRIPTION
Angles need to be wrapped on -pi, pi otherwise the control
rules generated from these will blow up (they are proportional
to the angle). Do that in this class so the user can't
inadvertantly make bugs.

There was a atan -> atan2 update in 0cdbb765a which didn't implement
atan2 correctly, this fixes that. We did not see the problem for a long
time simply because the divisor was 1.0 which is the same as multiplying
by 1.0.
