### PR TITLE
Deprecate potentially confusing xxx2str functions and provide healthier replacements

### DIFF
--- a/yocs_math_toolkit/include/yocs_math_toolkit/common.hpp
+++ b/yocs_math_toolkit/include/yocs_math_toolkit/common.hpp
@@ -79,6 +79,8 @@ void tf2pose(const tf::StampedTransform& tf, geometry_msgs::PoseStamped& pose);
 void pose2tf(const geometry_msgs::Pose& pose, tf::Transform& tf);
 void pose2tf(const geometry_msgs::PoseStamped& pose, tf::StampedTransform& tf);
 
+std::string vector2str3D(const geometry_msgs::Vector3& vector);
+std::string vector2str3D(const geometry_msgs::Vector3Stamped& vector);
 std::string point2str2D(const geometry_msgs::Point& point);
 std::string point2str2D(const geometry_msgs::PointStamped& point);
 std::string point2str3D(const geometry_msgs::Point& point);

--- a/yocs_math_toolkit/include/yocs_math_toolkit/common.hpp
+++ b/yocs_math_toolkit/include/yocs_math_toolkit/common.hpp
@@ -8,6 +8,17 @@
 #ifndef COMMON_HPP_
 #define COMMON_HPP_
 
+// deprecation macros
+#ifdef __GNUC__
+#define MTK_DEPRECATED __attribute__((deprecated))
+#elif defined(_MSC_VER)
+#define MTK_DEPRECATED __declspec(deprecated)
+#elif defined(__clang__)
+#define MTK_DEPRECATED  __attribute__((deprecated("MTK: Use of this method is deprecated")))
+#else
+#define MTK_DEPRECATED /* Nothing */
+#endif
+
 
 #include <tf/tf.h>
 
@@ -68,9 +79,19 @@ void tf2pose(const tf::StampedTransform& tf, geometry_msgs::PoseStamped& pose);
 void pose2tf(const geometry_msgs::Pose& pose, tf::Transform& tf);
 void pose2tf(const geometry_msgs::PoseStamped& pose, tf::StampedTransform& tf);
 
-const char* point2str(const geometry_msgs::Point& point);
-const char* pose2str(const geometry_msgs::Pose& pose);
-const char* pose2str(const geometry_msgs::PoseStamped& pose);
+std::string point2str2D(const geometry_msgs::Point& point);
+std::string point2str2D(const geometry_msgs::PointStamped& point);
+std::string point2str3D(const geometry_msgs::Point& point);
+std::string point2str3D(const geometry_msgs::PointStamped& point);
+std::string pose2str2D(const geometry_msgs::Pose& pose);
+std::string pose2str2D(const geometry_msgs::PoseStamped& pose);
+std::string pose2str3D(const geometry_msgs::Pose& pose);
+std::string pose2str3D(const geometry_msgs::PoseStamped& pose);
+
+// Deprecated, as you cannot call more than once in a single sentence; use the xxx2str2D/3D cousins instead
+MTK_DEPRECATED const char* point2str(const geometry_msgs::Point& point);
+MTK_DEPRECATED const char* pose2str(const geometry_msgs::Pose& pose);
+MTK_DEPRECATED const char* pose2str(const geometry_msgs::PoseStamped& pose);
 
 
 } /* namespace mtk */

--- a/yocs_math_toolkit/include/yocs_math_toolkit/common.hpp
+++ b/yocs_math_toolkit/include/yocs_math_toolkit/common.hpp
@@ -8,17 +8,6 @@
 #ifndef COMMON_HPP_
 #define COMMON_HPP_
 
-// deprecation macros
-#ifdef __GNUC__
-#define MTK_DEPRECATED __attribute__((deprecated))
-#elif defined(_MSC_VER)
-#define MTK_DEPRECATED __declspec(deprecated)
-#elif defined(__clang__)
-#define MTK_DEPRECATED  __attribute__((deprecated("MTK: Use of this method is deprecated")))
-#else
-#define MTK_DEPRECATED /* Nothing */
-#endif
-
 
 #include <tf/tf.h>
 
@@ -91,9 +80,10 @@ std::string pose2str3D(const geometry_msgs::Pose& pose);
 std::string pose2str3D(const geometry_msgs::PoseStamped& pose);
 
 // Deprecated, as you cannot call more than once in a single sentence; use the xxx2str2D/3D cousins instead
-MTK_DEPRECATED const char* point2str(const geometry_msgs::Point& point);
-MTK_DEPRECATED const char* pose2str(const geometry_msgs::Pose& pose);
-MTK_DEPRECATED const char* pose2str(const geometry_msgs::PoseStamped& pose);
+#include <ecl/config/macros.hpp>
+ECL_DEPRECATED const char* point2str(const geometry_msgs::Point& point);
+ECL_DEPRECATED const char* pose2str(const geometry_msgs::Pose& pose);
+ECL_DEPRECATED const char* pose2str(const geometry_msgs::PoseStamped& pose);
 
 
 } /* namespace mtk */

--- a/yocs_math_toolkit/include/yocs_math_toolkit/geometry.hpp
+++ b/yocs_math_toolkit/include/yocs_math_toolkit/geometry.hpp
@@ -44,6 +44,15 @@ double pitch(geometry_msgs::Pose pose);
 double pitch(geometry_msgs::PoseStamped pose);
 
 /**
+ * Shortcut to take the yaw of a transform/pose
+ * @param tf/pose
+ * @return Transform/pose's yaw
+ */
+double yaw(const tf::Transform& tf);
+double yaw(geometry_msgs::Pose pose);
+double yaw(geometry_msgs::PoseStamped pose);
+
+/**
  * Euclidean distance between 2D points; z coordinate is ignored
  * @param a point a
  * @param b point b

--- a/yocs_math_toolkit/src/lib/common.cpp
+++ b/yocs_math_toolkit/src/lib/common.cpp
@@ -63,6 +63,17 @@ const char* pose2str(const geometry_msgs::PoseStamped& pose)
   return (const char*)___buffer___;
 }
 
+std::string vector2str3D(const geometry_msgs::Vector3& vector)
+{
+  sprintf(___buffer___, "%.2f, %.2f, %.2f", vector.x, vector.y, vector.z);
+  return std::string(___buffer___);
+}
+
+std::string vector2str3D(const geometry_msgs::Vector3Stamped& vector)
+{
+  return vector2str3D(vector.vector);
+}
+
 std::string point2str2D(const geometry_msgs::Point& point)
 {
   sprintf(___buffer___, "%.2f, %.2f", point.x, point.y);

--- a/yocs_math_toolkit/src/lib/common.cpp
+++ b/yocs_math_toolkit/src/lib/common.cpp
@@ -59,7 +59,8 @@ const char* pose2str(const geometry_msgs::Pose& pose)
 
 const char* pose2str(const geometry_msgs::PoseStamped& pose)
 {
-  return pose2str(pose.pose);
+  sprintf(___buffer___, "%.2f, %.2f, %.2f", pose.pose.position.x, pose.pose.position.y, yaw(pose));
+  return (const char*)___buffer___;
 }
 
 std::string point2str2D(const geometry_msgs::Point& point)
@@ -87,7 +88,7 @@ std::string point2str3D(const geometry_msgs::PointStamped& point)
 std::string pose2str2D(const geometry_msgs::Pose& pose)
 {
   sprintf(___buffer___, "%.2f, %.2f, %.2f", pose.position.x, pose.position.y, yaw(pose));
-  return std::string(pose2str(pose));
+  return std::string(___buffer___);
 }
 
 std::string pose2str2D(const geometry_msgs::PoseStamped& pose)

--- a/yocs_math_toolkit/src/lib/common.cpp
+++ b/yocs_math_toolkit/src/lib/common.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "../../include/yocs_math_toolkit/common.hpp"
+#include "../../include/yocs_math_toolkit/geometry.hpp"
 
 
 namespace mtk
@@ -52,13 +53,58 @@ const char* point2str(const geometry_msgs::Point& point)
 
 const char* pose2str(const geometry_msgs::Pose& pose)
 {
-  sprintf(___buffer___, "%.2f, %.2f, %.2f", pose.position.x, pose.position.y, tf::getYaw(pose.orientation));
+  sprintf(___buffer___, "%.2f, %.2f, %.2f", pose.position.x, pose.position.y, yaw(pose));
   return (const char*)___buffer___;
 }
 
 const char* pose2str(const geometry_msgs::PoseStamped& pose)
 {
   return pose2str(pose.pose);
+}
+
+std::string point2str2D(const geometry_msgs::Point& point)
+{
+  sprintf(___buffer___, "%.2f, %.2f", point.x, point.y);
+  return std::string(___buffer___);
+}
+
+std::string point2str2D(const geometry_msgs::PointStamped& point)
+{
+  return point2str2D(point.point);
+}
+
+std::string point2str3D(const geometry_msgs::Point& point)
+{
+  sprintf(___buffer___, "%.2f, %.2f, %.2f", point.x, point.y, point.z);
+  return std::string(___buffer___);
+}
+
+std::string point2str3D(const geometry_msgs::PointStamped& point)
+{
+  return point2str3D(point.point);
+}
+
+std::string pose2str2D(const geometry_msgs::Pose& pose)
+{
+  sprintf(___buffer___, "%.2f, %.2f, %.2f", pose.position.x, pose.position.y, yaw(pose));
+  return std::string(pose2str(pose));
+}
+
+std::string pose2str2D(const geometry_msgs::PoseStamped& pose)
+{
+  return pose2str2D(pose.pose);
+}
+
+std::string pose2str3D(const geometry_msgs::Pose& pose)
+{
+  sprintf(___buffer___, "%.2f, %.2f, %.2f,  %.2f, %.2f, %.2f",
+          pose.position.x, pose.position.y, pose.position.z, roll(pose), pitch(pose), yaw(pose));
+  return std::string(___buffer___);
+}
+
+std::string pose2str3D(const geometry_msgs::PoseStamped& pose)
+{
+  return pose2str3D(pose.pose);
 }
 
 } /* namespace mtk */

--- a/yocs_math_toolkit/src/lib/geometry.cpp
+++ b/yocs_math_toolkit/src/lib/geometry.cpp
@@ -59,6 +59,21 @@ double pitch(geometry_msgs::PoseStamped pose)
   return pitch(pose.pose);
 }
 
+double yaw(const tf::Transform& tf)
+{
+  return tf::getYaw(tf.getRotation());
+}
+
+double yaw(geometry_msgs::Pose pose)
+{
+  return tf::getYaw(pose.orientation);
+}
+
+double yaw(geometry_msgs::PoseStamped pose)
+{
+  return yaw(pose.pose);
+}
+
 
 double distance2D(double x, double y)
 {


### PR DESCRIPTION
Deprecate xxx2str functions as you cannot call more than once in a single sentence; use the new xxx2str2D/3D cousins instead.

More related to aesthetics, I also added yaw functions as a shortcut of tf::getYaw to complement the existing roll and pitch functions.
