### PR TITLE
Remove applying decel factor from turning

### DIFF
--- a/yocs_velocity_smoother/src/velocity_smoother_nodelet.cpp
+++ b/yocs_velocity_smoother/src/velocity_smoother_nodelet.cpp
@@ -181,15 +181,7 @@ void VelocitySmoother::spin()
       }
 
       w_inc = target_vel.angular.z - last_cmd_vel.angular.z;
-      if ((robot_feedback == ODOMETRY) && (current_vel.angular.z*target_vel.angular.z < 0.0))
-      {
-        // countermarch (on robots with significant inertia; requires odometry feedback to be detected)
-        max_w_inc = decel_lim_w*period;
-      }
-      else
-      {
-        max_w_inc = ((w_inc*target_vel.angular.z > 0.0)?accel_lim_w:decel_lim_w)*period;
-      }
+      max_w_inc = accel_lim_w * period;
 
       // Calculate and normalise vectors A (desired velocity increment) and B (maximum velocity increment),
       // where v acts as coordinate x and w as coordinate y; the sign of the angle from A to B determines


### PR DESCRIPTION
When turning left (i think, or maybe it's tuning right), the deceleration factor was applied to the angular acceleration limits because the angular velocity was negative. This does not make sense, so remove it.
