### PR TITLE
Suppress smoother warnings that can arise from multiplexing

### DIFF
--- a/yocs_velocity_smoother/.settings/language.settings.xml
+++ b/yocs_velocity_smoother/.settings/language.settings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project>
+	<configuration id="cdt.managedbuild.toolchain.gnu.base.1279222440" name="Default">
+		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
+			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
+			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="(.*gcc)|(.*[gc]\+\+)|(clang)" prefer-non-shared="true"/>
+			<provider-reference id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" ref="shared-provider"/>
+			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
+		</extension>
+	</configuration>
+</project>

--- a/yocs_velocity_smoother/include/yocs_velocity_smoother/velocity_smoother_nodelet.hpp
+++ b/yocs_velocity_smoother/include/yocs_velocity_smoother/velocity_smoother_nodelet.hpp
@@ -54,6 +54,7 @@ private:
   } robot_feedback;  /**< What source to use as robot velocity feedback */
 
   std::string name;
+  bool quiet;        /**< Quieten some warnings that are unavoidable because of velocity multiplexing. **/
   double speed_lim_v, accel_lim_v, decel_lim_v;
   double speed_lim_w, accel_lim_w, decel_lim_w;
   double decel_factor;


### PR DESCRIPTION
Provides a parameter (default is false, so that it doesn't change existing behaviour) to disable the warning that can frequently arise from multiplexer usage. This tends to get in the way of debugging when using a teleop on top of navi.
