### PR TITLE
Configuration can come now directly as a yaml-formatted string

### DIFF
--- a/yocs_cmd_vel_mux/cfg/reload.cfg
+++ b/yocs_cmd_vel_mux/cfg/reload.cfg
@@ -7,6 +7,7 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 gen = ParameterGenerator()
 
 gen.add("yaml_cfg_file", str_t, 0, "Pathname to a yaml file for re-configuration of the mux", "")
+gen.add("yaml_cfg_data", str_t, 0, "Yaml-formatted string for re-configuration of the mux", "")
 
 # Second arg is node name it will run in (doc purposes only), third is generated filename prefix
 exit(gen.generate(PACKAGE, "yocs_cmd_vel_mux_reload", "reload"))


### PR DESCRIPTION
in addition to as a file path (but not both).

I find this way of dynamic reconfigure much more practical, as you don't need to create different yaml files for every possible configuration
