### PR TITLE
Fix deprecated compile warning

### DIFF
--- a/yocs_ar_pair_tracking/src/client/client.cpp
+++ b/yocs_ar_pair_tracking/src/client/client.cpp
@@ -52,7 +52,7 @@ void ARPairTrackingClient::createMirrorMarkers()
     mtk::tf2pose(marker_gb, kk.pose);
     global_markers_mirrors_.markers.push_back(kk);
 
-    ROS_DEBUG("Marker %d: %s", global_markers_.markers[i].id, mtk::pose2str(global_markers_.markers[i].pose.pose));
+    ROS_DEBUG("Marker %d: %s", global_markers_.markers[i].id, mtk::pose2str2D(global_markers_.markers[i].pose.pose).c_str());
 
     // TODO: In the current annotation design, it is impossible to record both left and right id of ar marker. 
   }


### PR DESCRIPTION
Partly fix for [this](https://bitbucket.org/yujinrobot/gopher_navigation/issues/132/compile-warnings)

[See also this.](https://github.com/yujinrobot/yujin_ocs/blob/9a1a0b6ba6c3a0f54fe03df794f26e1bcef3be37/yocs_math_toolkit/include/yocs_math_toolkit/common.hpp#L82)