### PR TITLE
Drop dependency on gencpp target

### DIFF
--- a/yocs_cmd_vel_mux/CMakeLists.txt
+++ b/yocs_cmd_vel_mux/CMakeLists.txt
@@ -26,7 +26,6 @@ include_directories(include ${catkin_INCLUDE_DIRS} ${yaml-cpp_INCLUDE_DIRS})
 
 # Nodelet library
 add_library(${PROJECT_NAME}_nodelet src/cmd_vel_mux_nodelet.cpp src/cmd_vel_subscribers.cpp)
-add_dependencies(${PROJECT_NAME}_nodelet geometry_msgs_gencpp)
 add_dependencies(${PROJECT_NAME}_nodelet ${PROJECT_NAME}_gencfg)
 
 target_link_libraries(${PROJECT_NAME}_nodelet ${catkin_LIBRARIES} ${yaml-cpp_LIBRARIES})


### PR DESCRIPTION
Not needed when using isolated build tools like `catkin_tools` and `colcon`, and throws this error:

```
--- stderr: yocs_cmd_vel_mux
CMake Warning (dev) at CMakeLists.txt:27 (add_dependencies):
  Policy CMP0046 is not set: Error on non-existent dependency in
  add_dependencies.  Run "cmake --help-policy CMP0046" for policy details.
  Use the cmake_policy command to set the policy and suppress this warning.

  The dependency target "geometry_msgs_gencpp" of target
  "yocs_cmd_vel_mux_nodelet" does not exist.
This warning is for project developers.  Use -Wno-dev to suppress it.

---
```