### PR TITLE
Changed variable type to size_t type 

### DIFF
--- a/yocs_cmd_vel_mux/src/cmd_vel_mux_nodelet.cpp
+++ b/yocs_cmd_vel_mux/src/cmd_vel_mux_nodelet.cpp
@@ -199,7 +199,7 @@ void CmdVelMuxNodelet::reloadConfiguration(yocs_cmd_vel_mux::reloadConfig &confi
 
   // (Re)create subscribers whose topic is invalid: new ones and those with changed names
   double longest_timeout = 0.0;
-  for (unsigned int i = 0; i < cmd_vel_subs.size(); i++)
+  for (size_t i = 0; i < cmd_vel_subs.size(); i++)
   {
     if (!cmd_vel_subs[i]->subs)
     {

--- a/yocs_cmd_vel_mux/src/cmd_vel_subscribers.cpp
+++ b/yocs_cmd_vel_mux/src/cmd_vel_subscribers.cpp
@@ -68,7 +68,7 @@ void CmdVelSubscribers::configure(const YAML::Node& node)
     }
 
     std::vector<std::shared_ptr<CmdVelSubs>> new_list(node.size());
-    for (unsigned int i = 0; i < node.size(); i++)
+    for (size_t i = 0; i < node.size(); i++)
     {
       // Parse entries on YAML
       std::string new_subs_name = node[i]["name"].Scalar();


### PR DESCRIPTION
In cmd_vel_mux_nodelet.cpp, cmd_vel_subs.size() is of type size_t and i is of type unsigned int, which are inconsistent types that present a security vulnerability to my team. In order to address this security vulnerability, I changed i in the for loop to be of type size_t to enable consistent variable types. In cmd_vel_subscribers.cpp, I made a similar change due to the same security vulnerability. 